### PR TITLE
lock deep-diff to 3.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gridpaint",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "a canvas for creating grid-based art in the browser",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/misterhat/gridpaint#readme",
   "dependencies": {
-    "deep-diff": "^0.3.4",
+    "deep-diff": "0.3.4",
     "file-saver": "^1.3.3",
     "inherits": "^2.0.3"
   },


### PR DESCRIPTION
lock deep diff to 0.3.4

deep-diff's latest release throws syntax errors.